### PR TITLE
publish: version 1.2.0

### DIFF
--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=~/.gnupg:create
   - --socket=gpg-agent
+  - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.keyring.SystemPrompter
   - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
@@ -38,5 +39,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/konstantintutsch/Lock.git
-        tag: v1.1.3
-        commit: 91531eacafe98e86bbd70a518d9f0a0e3a7a73c6
+        tag: v1.2.0
+        commit: a8c46a9cff3fbe23d7defbd6799913502372b6d6


### PR DESCRIPTION
fix: grant talk permission with org.freedesktop.secrets

This commit allows GnuPG Made Easy to access the system pinentry.

Resolves konstantintutsch/Lock#30, resolves konstantintutsch/Lock#23
