### PR TITLE
publish: version 1.2.1

### DIFF
--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -9,7 +9,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --filesystem=~/.gnupg:create
-  - --socket=gpg-agent
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.keyring.SystemPrompter
   - --talk-name=org.gtk.vfs.*
@@ -39,5 +38,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/konstantintutsch/Lock.git
-        tag: v1.2.0
-        commit: a8c46a9cff3fbe23d7defbd6799913502372b6d6
+        tag: v1.2.1
+        commit: 59fd3bb0d2c1288d731b57d9192d6414afbe9ae6


### PR DESCRIPTION
build: remove --socket=gpg-agent from Flatpak

This permissions change fixes unexpected behaviour with Pinentry interactions.

Resolves konstantintutsch/Lock#32
